### PR TITLE
Mobile responsiveness 

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import '../app.postcss';
+  import calcIcon from '$lib/assets/calc.svg';
 </script>
 
 <main>
@@ -17,7 +18,12 @@
           >
         </li>
         <li>
-          <a href="/calc/program"> <button class="btn btn-primary">Kalkulator</button></a>
+          <a href="/calc/program" class="btn btn-primary" aria-label="Kalkulator">
+            <span class="sm:hidden">
+              <img src={calcIcon} alt="" class="h-5 w-5" />
+            </span>
+            <span class="hidden sm:inline">Kalkulator</span>
+          </a>
         </li>
       </ul>
     </div>

--- a/src/routes/calc/program/+page.svelte
+++ b/src/routes/calc/program/+page.svelte
@@ -111,28 +111,28 @@
   <div class="grid grid-cols-2 gap-4">
     <div class="flex flex-column items-center">
       <div class="avatar">
-        <div class="bg-base-content rounded-full w-12" />
+        <div class="bg-base-content rounded-full w-12 mr-2 sm:mr-0" />
       </div>
       <div class="divider lg:divider-horizontal" />
       <p>{SubjectType.Mandatory}</p>
     </div>
     <div class="flex flex-column items-center">
       <div class="avatar">
-        <div class="bg-warning rounded-full w-12" />
+        <div class="bg-warning rounded-full w-12 mr-2 sm:mr-0" />
       </div>
       <div class="divider lg:divider-horizontal" />
       <p>{SubjectType.Disciplinary}</p>
     </div>
     <div class="flex flex-column items-center">
       <div class="avatar">
-        <div class="bg-info rounded-full w-12" />
+        <div class="bg-info rounded-full w-12 mr-2 sm:mr-0" />
       </div>
       <div class="divider lg:divider-horizontal" />
       <p>{SubjectType.Directionary}</p>
     </div>
     <div class="flex flex-column items-center">
       <div class="avatar">
-        <div class="bg-success rounded-full w-12" />
+        <div class="bg-success rounded-full w-12 mr-2 sm:mr-0" />
       </div>
       <div class="divider lg:divider-horizontal" />
       <p>{SubjectType.Common}</p>


### PR DESCRIPTION
Closes #26 

On mobile (small screens):
- Only the calculator icon is shown, to prevent horizontal scrollbar
  <img width="332" height="83" alt="image" src="https://github.com/user-attachments/assets/e5a8316c-4d0a-494e-a196-2d621a497ed2" />

- Added margin right in the calculator section
  <img width="326" height="147" alt="image" src="https://github.com/user-attachments/assets/e8f1ea14-365f-42a9-bff8-7c4119f1b64f" />
